### PR TITLE
fixed syntax for install dependices and removed password

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[dev, tests]
+          pip install -e .[dev,tests]
 
       # Run pytest with coverage
       - name: Run tests with coverage
@@ -69,4 +69,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}


### PR DESCRIPTION
- fix #48
- removed space in this line: `pip install -e .[dev, tests]`
- removed password because it's not needed
