### PR TITLE
Fix grammar and typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ pytest
 
 ### Building documentation
 
-Documentation needs to be update when changes are made. You can build the documentation locally using `quartodoc`:
+Documentation needs to be updated when changes are made. You can build the documentation locally using `quartodoc`:
 
 ```bash
 quartodoc build
@@ -92,8 +92,7 @@ We follow the [PEP 8](https://peps.python.org/pep-0008/) style guide for Python 
 
 The project repository contains three protected branches. All new features and bug fixes should be developed in independent development branches created from `otter`. Once changes are complete and tested, a pull request should be opened to merge the development branch back into `otter`. After review, changes from `otter` can be merged into `main` for release.
 
-* `main`: the production branch containing the latest stable release.
-ruff check . When merged from `otter`,
+* `main`: the production branch containing the latest stable release. When merged from `otter`,
   * code style is checked  (pass enforced);
   * test suites are run (pass enforced);
   * documentation is built and published;


### PR DESCRIPTION
This pull request makes minor improvements to the `README.md` documentation. The changes correct a typo and clarify the description of the `main` branch workflow.

* Fixed typo in documentation instructions, changing "Documentation needs to be update" to "Documentation needs to be updated".
* Clarified the description of the `main` branch by removing a misplaced phrase and improving workflow explanation.
