### PR TITLE
Bump version from 1.0.2 to 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires = ["hatchling"]
 [project]
 name = "wordguess"
 # You can chose to use dynamic versioning with hatch or static where you add it manually.
-version = "1.0.2"
+version = "2.0.0"
 
 description = "A Python package with essential functions for a word-guessing game, inspired by Wordle."
 authors = [


### PR DESCRIPTION
- fix #58 
- just changed the version from `1.0.2` to `2.0.0` in toml file so that when we merge with main, we have the updated package published to TestPyPI
