### PR TITLE
Add validation for penalty rate and expand tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to this project will be documented in this file.
 - Added one more test case in `tests/unit/test_result_to_pattern.py`
 - Added three test cases in `tests/unit/test_get_score.py`
 - Added one more test case in `tests/unit/test_get_result.py`
+- Added validation for penalty rate in `src/wordguess/get_score.py`
 - Added validation for empty result lists in `src/wordguess/get_score.py`
 - Removed unused `docs` directory and Sphinx configuration
 - Removed unused GitHub Actions workflows

--- a/src/wordguess/get_score.py
+++ b/src/wordguess/get_score.py
@@ -68,6 +68,10 @@ def get_score(
         raise TypeError("All elements in result must be strings.")
     if not isinstance(penalty, bool):
         raise TypeError("Penalty must be a boolean value.")
+    if result == []:
+        raise ValueError("Result list must not be empty.")
+    if penalty_rate < 0 or penalty_rate > 1:
+        raise ValueError("Penalty rate must be between 0 and 1.")
     if any(r == "" for r in result):
         raise ValueError("All result strings must not be empty.")
     if not all(all(c in "012" for c in r) for r in result):

--- a/tests/unit/test_get_result.py
+++ b/tests/unit/test_get_result.py
@@ -8,7 +8,7 @@ def mock_corpus():
     return ["apple", "apply", "stare", "tears", "abort", "alarm", "books", "slope"]
 
 
-def test_get_result_value_errors(mock_corpus):
+def test_get_result_value_error(mock_corpus):
     """Test that ValueErrors are raised for length mismatch or invalid words."""
     with pytest.raises(ValueError, match="same length"):
         get_result("apple", "longword", corpus=mock_corpus)
@@ -20,7 +20,7 @@ def test_get_result_value_errors(mock_corpus):
         get_result("zzzzz", "apple", corpus=mock_corpus)
 
 
-def test_get_result_type_errors():
+def test_get_result_type_error():
     """Test that TypeError is raised for non-string inputs."""
     with pytest.raises(TypeError, match="must be strings"):
         get_result("apple", 12345)
@@ -41,3 +41,6 @@ def test_get_result(mock_corpus):
 
     # Test with repeated letters
     assert get_result("abort", "alarm", corpus=mock_corpus) == "20020"
+
+    # Test with all correct
+    assert get_result("apple", "apple", corpus=mock_corpus) == "22222"

--- a/tests/unit/test_get_score.py
+++ b/tests/unit/test_get_score.py
@@ -70,6 +70,15 @@ def test_get_score_no_penalty():
         == expected_score
     )
 
+    result = ["111", "122"]
+    penalty = True
+    penalty_rate = 0.333
+    expected_score = 55.58
+    assert (
+        get_score(result=result, penalty=penalty, penalty_rate=penalty_rate)
+        == expected_score
+    )
+
 
 def test_get_score_type_error():
     """
@@ -102,3 +111,9 @@ def test_get_score_value_error():
 
     with pytest.raises(ValueError, match="must not be empty"):
         get_score(["012", ""])
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        get_score([])
+
+    with pytest.raises(ValueError, match="must be between 0 and 1"):
+        get_score(["012", "122"], penalty=True, penalty_rate=1.5)

--- a/tests/unit/test_result_to_pattern.py
+++ b/tests/unit/test_result_to_pattern.py
@@ -25,8 +25,13 @@ def test_result_to_pattern():
     actual_3 = result_to_pattern(result_3)
     assert actual_3 == expected_3, f"Expected {expected_3} but got {actual_3}"
 
+    result_4 = "0" * 1000 + "1" * 1000 + "2" * 1000
+    expected_4 = "⬛" * 1000 + "🟨" * 1000 + "🟩" * 1000
+    actual_4 = result_to_pattern(result_4)
+    assert actual_4 == expected_4, "Failed on very long string input."
 
-def test_result_to_pattern_input_type():
+
+def test_result_to_pattern_type_error():
     """
     Test that result_to_pattern throws an error when the
     input is the incorrect type (i.e., not a string).
@@ -44,7 +49,7 @@ def test_result_to_pattern_input_type():
         result_to_pattern(result_3)
 
 
-def test_result_to_pattern_chars():
+def test_result_to_pattern_value_error():
     """
     Test that result_to_pattern throws an error when the
     input contains characters other than '0', '1' or '2'.


### PR DESCRIPTION
Added validation in get_score.py to ensure penalty_rate is between 0 and 1. Updated and expanded unit tests for get_score, get_result, and result_to_pattern to cover new validation and edge cases. Also improved test naming consistency.

- [x] fix #51 